### PR TITLE
Fix link to 2023 survey PDF report

### DIFF
--- a/2023/README.md
+++ b/2023/README.md
@@ -1,7 +1,7 @@
 # 2023 Open Source Program Survey Results
 
 * The announcements with Survey Key findings can be found [here](https://todogroup.org/blog/2023-state-of-ospo/)
-* The PDF report can be found [here](https://github.com/todogroup/osposurvey/files/12658370/2023StateofOSPOs-Infographic.pdf)
+* The PDF report can be found [here](https://github.com/todogroup/todogroup.org/files/12641293/STATE_OSPO_2023.pdf)
 
 * The Guide to use the CSV files and data can be found [here](https://github.com/todogroup/osposurvey/blob/main/2023/csv-files-and-data-guide.md)
     * Raw data is located [here](https://github.com/todogroup/osposurvey/blob/main/2023/RawData.csv)


### PR DESCRIPTION
Link to survey was mistakenly pointing to infographic instead of PDF report.